### PR TITLE
Add macOS 14 (Sonoma) support

### DIFF
--- a/PasteClip/Models/ClipboardItem.swift
+++ b/PasteClip/Models/ClipboardItem.swift
@@ -5,8 +5,6 @@ import UniformTypeIdentifiers
 
 @Model
 final class ClipboardItem {
-    #Unique<ClipboardItem>([\.contentHash])
-    #Index<ClipboardItem>([\.copiedAt], [\.contentHash], [\.sourceAppBundleId])
 
     var id: UUID
     var contentTypeRaw: String

--- a/PasteClip/Models/ExcludedApp.swift
+++ b/PasteClip/Models/ExcludedApp.swift
@@ -3,7 +3,6 @@ import SwiftData
 
 @Model
 final class ExcludedApp {
-    #Unique<ExcludedApp>([\.bundleId])
 
     var bundleId: String
     var appName: String

--- a/project.yml
+++ b/project.yml
@@ -2,7 +2,7 @@ name: PasteClip
 options:
   bundleIdPrefix: com.minsang
   deploymentTarget:
-    macOS: "15.0"
+    macOS: "14.0"
   xcodeVersion: "16.0"
   createIntermediateGroups: true
   developmentLanguage: en
@@ -10,7 +10,7 @@ options:
 settings:
   base:
     SWIFT_VERSION: "6.0"
-    MACOSX_DEPLOYMENT_TARGET: "15.0"
+    MACOSX_DEPLOYMENT_TARGET: "14.0"
     ENABLE_USER_SCRIPT_SANDBOXING: "YES"
 
 packages:


### PR DESCRIPTION
## Summary
- macOS 15 전용 SwiftData 매크로(`#Unique`, `#Index`) 제거
- 배포 타겟을 macOS 15.0 → 14.0으로 하향

## Test plan
- [x] Debug 빌드 성공 확인
- [x] 앱 실행 및 기본 기능 QA 완료

Closes #1