### PR TITLE
Allow ad-hoc release builds without a Sparkle signing key

### DIFF
--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -216,7 +216,18 @@ SIGN_UPDATE=$(find "${HOME}/Library/Developer/Xcode/DerivedData" "${PROJECT_DIR}
 if [ -x "${SIGN_UPDATE}" ]; then
     echo ""
     echo "==> Signing DMG with EdDSA..."
-    SIGN_OUTPUT=$("${SIGN_UPDATE}" "${DMG_OUTPUT}" 2>&1)
+    SIGN_FAILED=false
+    if ! SIGN_OUTPUT=$("${SIGN_UPDATE}" "${DMG_OUTPUT}" 2>&1); then
+        if [ "${SIGN_IDENTITY}" = "-" ] && echo "${SIGN_OUTPUT}" | grep -q "Signing key not found"; then
+            SIGN_FAILED=true
+            echo "    WARNING: Sparkle signing key not configured; continuing ad-hoc build"
+            echo "    sign_update output: ${SIGN_OUTPUT}"
+        else
+            echo "    FATAL: Sparkle EdDSA signing failed"
+            echo "    sign_update output: ${SIGN_OUTPUT}"
+            exit 1
+        fi
+    fi
     ED_SIGNATURE=$(echo "${SIGN_OUTPUT}" | grep "sparkle:edSignature" | sed 's/.*sparkle:edSignature="\([^"]*\)".*/\1/' || true)
 
     if [ -n "${ED_SIGNATURE}" ]; then
@@ -240,7 +251,11 @@ if [ -x "${SIGN_UPDATE}" ]; then
             ' "${APPCAST}" > "${APPCAST}.tmp" && mv "${APPCAST}.tmp" "${APPCAST}"
             echo "    appcast.xml updated with signature and file size"
         fi
-    else
+    elif [ "${SIGN_IDENTITY}" != "-" ]; then
+        echo "    FATAL: Could not extract Sparkle EdDSA signature"
+        echo "    sign_update output: ${SIGN_OUTPUT}"
+        exit 1
+    elif [ "${SIGN_FAILED}" = false ]; then
         echo "    WARNING: Could not extract EdDSA signature"
         echo "    sign_update output: ${SIGN_OUTPUT}"
     fi


### PR DESCRIPTION
## Description

Fixes local ad-hoc release builds failing at the optional Sparkle EdDSA signing step when the contributor does not have the maintainer's Sparkle signing key.

With `set -euo pipefail`, the existing `SIGN_OUTPUT=$(sign_update ...)` assignment exits the script immediately when Sparkle reports a missing key, so the warning/fallback logic below it is never reached. This can make a fully built and code-signing-verified DMG end with exit code 1.

This change:

- captures `sign_update` failures instead of letting `set -e` abort first;
- continues only for an ad-hoc build when Sparkle specifically reports `Signing key not found`;
- keeps unexpected EdDSA failures fatal;
- keeps Developer ID release builds strict, including treating a missing EdDSA signature as fatal.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Other (please describe):

## How to Test

1. Run `SIGN_IDENTITY='-' bash scripts/build-release.sh` on a machine without a Sparkle EdDSA private key.
2. Confirm the archive, DMG creation, and deep code-signing verification succeed; `sign_update` reports the missing key as a warning; and the script exits 0.
3. Run `xcodegen generate && xcodebuild -project PasteClip.xcodeproj -scheme PasteClip -configuration Debug build` and confirm the project builds successfully.

Tested locally with the real Sparkle `sign_update` failure:

`ERROR! Signing key not found for account ed25519. Please run generate_keys tool first or provide key with --ed-key-file <private_key_file>`

The resulting ad-hoc release completed successfully and the DMG app passed `codesign --verify --deep --strict`.

## Checklist

- [x] I have tested this change on macOS 15+
- [x] The project builds without warnings (`xcodegen generate && xcodebuild`)
- [x] I have followed the existing code style and conventions
- [x] I have updated documentation if needed
