### PR TITLE
Document terminal image paste workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,18 @@ PasteClip is signed with an Apple Developer ID and notarized by Apple (as of v1.
 
 The global shortcuts can be changed in **Settings → Shortcuts**.
 
+### Image clips in terminal apps
+
+Selecting an image clip puts the image back on the macOS clipboard, but a shell prompt itself cannot accept image data. The app or CLI running inside the terminal must support clipboard image input.
+
+For example, with Codex CLI on macOS:
+
+1. Press `⌘ ⇧ V` and select the image clip you want to reuse.
+2. Return to Codex without copying anything else.
+3. Press `Control + V` in Codex to attach the clipboard image.
+
+Codex uses `Control + V` for image attachments rather than the usual macOS `⌘ V` text-paste shortcut. Other terminal apps may use a different image-paste workflow.
+
 ### Keyboard shortcuts
 
 | Action | Default shortcut |


### PR DESCRIPTION
## Description

Documents how image clips behave in terminal workflows.

PasteClip can restore an image to the macOS clipboard, but a shell prompt itself cannot consume image data; the program running inside the terminal must support clipboard image input. The README now makes that distinction explicit and includes a verified Codex CLI example using `Control + V` for image attachment.

This should help avoid the common assumption that selecting an image clip will display or paste the image directly into a shell prompt with the usual macOS `⌘ V` shortcut.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactoring (no functional changes)
- [x] Documentation update
- [ ] Other (please describe):

## How to Test

1. Copy an image and let PasteClip record it.
2. Copy something else, then open PasteClip with `⌘ ⇧ V` and select the earlier image clip.
3. Return to Codex CLI on macOS and press `Control + V`.
4. Confirm Codex adds the clipboard image as an attachment (for example, `[Image #1]`).

The workflow was manually verified with PasteClip v1.1.11, iTerm2, and Codex CLI on macOS.

## Checklist

- [x] I have tested this change on macOS 15+
- [x] The project builds without warnings (`xcodegen generate && xcodebuild`)
- [x] I have followed the existing code style and conventions
- [x] I have updated documentation if needed
