### PR TITLE
Paste as plain text (#14)

### DIFF
--- a/Clipbara/AppState.swift
+++ b/Clipbara/AppState.swift
@@ -65,6 +65,14 @@ final class AppState {
         }
     }
 
+    /// 패널/핀보드 카드에서 공통으로 쓰는 붙여넣기 경로.
+    /// - Parameter asPlainText: nil이면 설정 + Shift 조합으로 자동 판단
+    func paste(_ item: ClipboardItem, asPlainText: Bool? = nil) {
+        clipboardMonitor.skipNextChange()
+        pasteService.paste(item: item, asPlainText: asPlainText)
+        hidePanel()
+    }
+
     func hidePanel() {
         previewItem = nil
         panelToast = nil

--- a/Clipbara/Services/PasteService.swift
+++ b/Clipbara/Services/PasteService.swift
@@ -5,7 +5,34 @@ struct PasteService {
 
     private static let tempDir = NSTemporaryDirectory() + "Clipbara/"
 
-    func paste(item: ClipboardItem) {
+    /// 설정 > General의 "항상 일반 텍스트로 붙여넣기" 값
+    nonisolated static let alwaysPlainTextDefaultsKey = "alwaysPastePlainText"
+
+    /// 서식 제거가 의미 있는 항목인지 (RTF/HTML만 해당)
+    static func supportsPlainText(_ item: ClipboardItem) -> Bool {
+        switch item.contentType {
+        case .richText, .html:
+            return !(item.textContent?.isEmpty ?? true)
+        default:
+            return false
+        }
+    }
+
+    /// 기본값(설정)과 Shift 수정자를 XOR로 합친다.
+    /// 설정이 꺼져 있으면 Shift = 서식 제거, 켜져 있으면 Shift = 서식 유지.
+    static func resolvePlainText() -> Bool {
+        let always = UserDefaults.standard.bool(forKey: alwaysPlainTextDefaultsKey)
+        let shiftHeld = NSEvent.modifierFlags.contains(.shift)
+        return always != shiftHeld
+    }
+
+    /// - Parameter asPlainText: nil이면 설정 + Shift 조합으로 자동 판단
+    func paste(item: ClipboardItem, asPlainText: Bool? = nil) {
+        if asPlainText ?? Self.resolvePlainText(), Self.supportsPlainText(item) {
+            pastePlainText(item: item)
+            return
+        }
+
         let pasteboard = NSPasteboard.general
         pasteboard.clearContents()
 

--- a/Clipbara/Views/ClipboardCardView.swift
+++ b/Clipbara/Views/ClipboardCardView.swift
@@ -62,7 +62,12 @@ struct ClipboardCardView: View {
 
     @ViewBuilder
     private var menuItems: some View {
-        Button("Paste") { onPaste(item) }
+        if PasteService.supportsPlainText(item) {
+            Button("Paste with Formatting") { appState.paste(item, asPlainText: false) }
+            Button("Paste as Plain Text") { appState.paste(item, asPlainText: true) }
+        } else {
+            Button("Paste") { onPaste(item) }
+        }
         if showsManagementMenu {
             Divider()
             Button("Rename") {

--- a/Clipbara/Views/Settings/GeneralSettingsTab.swift
+++ b/Clipbara/Views/Settings/GeneralSettingsTab.swift
@@ -7,6 +7,7 @@ struct GeneralSettingsTab: View {
     @Environment(\.modelContext) private var modelContext
     @Environment(AppState.self) private var appState
     @AppStorage("historyLimit") private var historyLimit: Int = 500
+    @AppStorage(PasteService.alwaysPlainTextDefaultsKey) private var alwaysPastePlainText: Bool = false
     @State private var launchAtLogin: Bool = SMAppService.mainApp.status == .enabled
     @State private var transferMessage: String?
     @State private var showTransferAlert = false
@@ -34,6 +35,23 @@ struct GeneralSettingsTab: View {
                         launchAtLogin = !newValue
                     }
                 }
+
+            Section("Pasting") {
+                HStack {
+                    VStack(alignment: .leading, spacing: 2) {
+                        HStack(spacing: 5) {
+                            Text("Always Paste as Plain Text")
+                            InfoHoverButton(text: "Removes fonts, colors, and links from rich text and HTML clips, pasting only the text.")
+                        }
+                        Text("Hold \u{21e7} while pasting to switch for a single paste.")
+                            .font(.system(size: 11))
+                            .foregroundStyle(.secondary)
+                    }
+                    Spacer()
+                    Toggle("", isOn: $alwaysPastePlainText)
+                        .labelsHidden()
+                }
+            }
 
             Section("Backup") {
                 LabeledContent("Export history, pinboards, and settings to a JSON file.") {


### PR DESCRIPTION
Closes #14

## What

- `PasteService.paste(item:asPlainText:)`: `nil`이면 설정값과 Shift 수정자를 XOR로 판단해서 서식 제거 여부 결정
- 카드 컨텍스트 메뉴: RTF/HTML 클립일 때만 `Paste with Formatting` / `Paste as Plain Text`로 분리
- 설정 > General에 `Always Paste as Plain Text` 토글 추가 (기본 off)

Shift를 누른 채 붙여넣으면 설정과 반대 동작이 한 번만 적용된다. 기존 `paste(item:)` 호출부(Return 키, 카드 클릭, 프리뷰, 메뉴바)는 시그니처 그대로라 자동으로 수정자 판단 경로를 탄다.

## Not in this PR (의도적)

- 버전 bump, appcast.xml, 태그, 릴리스: **1.3.0(23)이 App Store 심사 중**이라 심사 통과 + GitHub 릴리스 이후로 미룸
- README 기능 목록: 아직 배포되지 않은 기능이라 릴리스 시점에 같이 갱신
- PastePlain이 하는 공백/줄바꿈 정리, 인코딩 복구, OCR은 스코프 밖

## 검증 상태

- 문법 파싱(`swiftc -parse`) 통과
- **전체 빌드 및 E2E 미검증**: 작업 환경에서 SwiftPM 의존성 해결이 실패해서 로컬 빌드 필요
  ```
  DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -project Clipbara.xcodeproj -scheme Clipbara -configuration Debug build
  ```
  확인할 것: (1) 서식 있는 웹 텍스트 복사 후 Shift+클릭 → 평문만 클립보드에 들어가는지 (2) 그냥 클릭 → 기존처럼 서식 유지되는지 (3) 설정 토글 켠 뒤 동작이 뒤집히는지