### PR TITLE
Paste as plain text (#14)

### DIFF
--- a/Clipbara/AppState.swift
+++ b/Clipbara/AppState.swift
@@ -65,6 +65,14 @@ final class AppState {
         }
     }
 
+    /// Shared paste path for panel and pinboard cards.
+    /// - Parameter asPlainText: `nil` resolves from the setting combined with the Shift modifier.
+    func paste(_ item: ClipboardItem, asPlainText: Bool? = nil) {
+        clipboardMonitor.skipNextChange()
+        pasteService.paste(item: item, asPlainText: asPlainText)
+        hidePanel()
+    }
+
     func hidePanel() {
         previewItem = nil
         panelToast = nil

--- a/Clipbara/Services/PasteService.swift
+++ b/Clipbara/Services/PasteService.swift
@@ -5,7 +5,34 @@ struct PasteService {
 
     private static let tempDir = NSTemporaryDirectory() + "Clipbara/"
 
-    func paste(item: ClipboardItem) {
+    /// Backing key for the "Always Paste as Plain Text" setting (Settings > General).
+    nonisolated static let alwaysPlainTextDefaultsKey = "alwaysPastePlainText"
+
+    /// Whether stripping formatting is meaningful for this item (RTF/HTML only).
+    static func supportsPlainText(_ item: ClipboardItem) -> Bool {
+        switch item.contentType {
+        case .richText, .html:
+            return !(item.textContent?.isEmpty ?? true)
+        default:
+            return false
+        }
+    }
+
+    /// Combines the setting with the Shift modifier using XOR.
+    /// Setting off: Shift strips formatting. Setting on: Shift keeps formatting.
+    static func resolvePlainText() -> Bool {
+        let always = UserDefaults.standard.bool(forKey: alwaysPlainTextDefaultsKey)
+        let shiftHeld = NSEvent.modifierFlags.contains(.shift)
+        return always != shiftHeld
+    }
+
+    /// - Parameter asPlainText: `nil` resolves from the setting combined with the Shift modifier.
+    func paste(item: ClipboardItem, asPlainText: Bool? = nil) {
+        if asPlainText ?? Self.resolvePlainText(), Self.supportsPlainText(item) {
+            pastePlainText(item: item)
+            return
+        }
+
         let pasteboard = NSPasteboard.general
         pasteboard.clearContents()
 

--- a/Clipbara/Views/ClipboardCardView.swift
+++ b/Clipbara/Views/ClipboardCardView.swift
@@ -62,7 +62,12 @@ struct ClipboardCardView: View {
 
     @ViewBuilder
     private var menuItems: some View {
-        Button("Paste") { onPaste(item) }
+        if PasteService.supportsPlainText(item) {
+            Button("Paste with Formatting") { appState.paste(item, asPlainText: false) }
+            Button("Paste as Plain Text") { appState.paste(item, asPlainText: true) }
+        } else {
+            Button("Paste") { onPaste(item) }
+        }
         if showsManagementMenu {
             Divider()
             Button("Rename") {

--- a/Clipbara/Views/Settings/GeneralSettingsTab.swift
+++ b/Clipbara/Views/Settings/GeneralSettingsTab.swift
@@ -7,6 +7,7 @@ struct GeneralSettingsTab: View {
     @Environment(\.modelContext) private var modelContext
     @Environment(AppState.self) private var appState
     @AppStorage("historyLimit") private var historyLimit: Int = 500
+    @AppStorage(PasteService.alwaysPlainTextDefaultsKey) private var alwaysPastePlainText: Bool = false
     @State private var launchAtLogin: Bool = SMAppService.mainApp.status == .enabled
     @State private var transferMessage: String?
     @State private var showTransferAlert = false
@@ -34,6 +35,23 @@ struct GeneralSettingsTab: View {
                         launchAtLogin = !newValue
                     }
                 }
+
+            Section("Pasting") {
+                HStack {
+                    VStack(alignment: .leading, spacing: 2) {
+                        HStack(spacing: 5) {
+                            Text("Always Paste as Plain Text")
+                            InfoHoverButton(text: "Removes fonts, colors, and links from rich text and HTML clips, pasting only the text.")
+                        }
+                        Text("Hold \u{21e7} while pasting to switch for a single paste.")
+                            .font(.system(size: 11))
+                            .foregroundStyle(.secondary)
+                    }
+                    Spacer()
+                    Toggle("", isOn: $alwaysPastePlainText)
+                        .labelsHidden()
+                }
+            }
 
             Section("Backup") {
                 LabeledContent("Export history, pinboards, and settings to a JSON file.") {


### PR DESCRIPTION
Refs #14 (kept open until this ships in a release)

## What

- `PasteService.paste(item:asPlainText:)`: passing `nil` resolves the mode from the setting XOR the Shift modifier.
- Card context menu is split into `Paste with Formatting` / `Paste as Plain Text`, shown only for RTF and HTML clips.
- New `Always Paste as Plain Text` toggle in Settings > General (off by default).

Holding Shift while pasting flips the configured behavior for that single paste. Existing `paste(item:)` call sites (Return key, card click, preview, menu bar) keep their signature and go through the modifier-aware path automatically.

## Deliberately out of scope

- Version bump, `appcast.xml`, tag, and release: 1.3.0 (23) is currently in App Store review, so shipping is deferred until review clears and the GitHub release is out.
- README feature list: will be updated together with the release.
- Whitespace/line-break cleanup, encoding repair, and OCR (things PastePlain also does) are not part of this issue.

## Verification status

- `swiftc -parse` passes on the changed files.
- Full build and E2E are not done yet. They will be run locally before release:
  ```
  DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -project Clipbara.xcodeproj -scheme Clipbara -configuration Debug build
  ```
  Checks: (1) copy formatted web text, Shift+click a card, and confirm only plain text lands on the clipboard, (2) a normal click still keeps formatting, (3) turning the setting on inverts both behaviors.